### PR TITLE
Use alpine-base 3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hackinglab/alpine-base
+FROM hackinglab/alpine-base:3.2
 MAINTAINER Stephan Hauser <stephan.hauser@compass-security.com>
 
 RUN apk add -U \


### PR DESCRIPTION
Specify tag 3.2 to ensure alpine 3.13 is used.